### PR TITLE
stop toDoList reset when open 3x or chrome closed

### DIFF
--- a/brain.js
+++ b/brain.js
@@ -42,14 +42,6 @@ chrome.storage.local.get('toDoList', function getData(data) {
   }
 });
 
-chrome.storage.local.set(
-  {
-    'currentDate': getDate(),
-    'toDoList' : toDoList
-  }
-);
-
-
 function getDate() {
   let today = new Date();
   let dd = String(today.getDate()).padStart(2, '0');


### PR DESCRIPTION
One change for toDoList to stay in memory, even when Chrome is closed: stop setting toDoList on start. The extension also seems to "forget" what was clicked if you open/close it 3 or more times in a row. See the suggested change in ["Files changed"](https://github.com/marko-polo-cheno/Habit-Tracker-Extension/pull/1/files). 

btw, I also noticed the date sometimes was getting undefined when you open it in a fresh Chrome window. 

"Merge pull request" basically means "combine requested/suggested changes". https://help.github.com/en/articles/merging-a-pull-request#merging-a-pull-request-on-github